### PR TITLE
Update CSS for navbar to change for mobile screens (425 px or less)

### DIFF
--- a/source/header/header.css
+++ b/source/header/header.css
@@ -138,7 +138,7 @@ header {
         justify-content: center;
         gap: 15px;
         max-width: 100%;
-        max-height: 35%;
+        max-height: 40%;
         margin-right: 70px;
         margin-bottom: 3px;
         margin-top: 5px;

--- a/source/header/header.css
+++ b/source/header/header.css
@@ -2,10 +2,8 @@ header {
     display: flex;
     justify-content: space-around;
     gap: 60px;
-
     padding: 15px 25px;
     background-color: #E5C775;
-
     font-family: sans-serif;
 }
 
@@ -18,10 +16,6 @@ header {
     justify-content: space-between;
     align-items: center;
     gap: 25px;
-
-    flex-grow: 1;
-    gap: 25px;
-
     flex-grow: 1;
 }
 
@@ -29,27 +23,22 @@ header {
     display: flex;
     flex-flow: row wrap;
     flex-basis: 1000px;
-
     gap: 20px;
 }
 
 .stat {
     background-color: #F6F6F6;
     border-radius: 12px;
-
     min-width: 200px;
     max-width: 700px;
     height: 40px;
-
     display: flex;
     flex-direction: row;
     justify-content: center;
     align-items: center;
     gap: 10px;
-
     padding: 7.5px 0px;
-
-    flex: 1 0 0;
+    flex: 1 1 0;
 }
 
 .stat p {
@@ -61,7 +50,7 @@ header {
 }
 
 .stat-caption {
-    color: #2D2E2EB2
+    color: #2D2E2EB2;
 }
 
 #check {
@@ -72,14 +61,11 @@ header {
     display: flex;
     align-items: center;
     justify-content: space-between;
-
     background-color: #F6F6F6;
     border-radius: 400px;
-
     height: 50px;
     gap: 14px;
-
-    margin-left: 50px;
+    margin-left: 150px;
 }
 
 .menu a {
@@ -87,6 +73,7 @@ header {
     color: #2D2E2E;
     margin-left: 28px;
 }
+
 .profile-icon {
     background-color: #234654;
     padding: 12px;
@@ -95,7 +82,6 @@ header {
 
 /* tablet css */
 @media (max-width: 1025px) {
-
     header {
         height: 200px;
         gap: 0px;
@@ -103,14 +89,12 @@ header {
 
     .logo {
         height: 60px;
-
         position: absolute;
         left: 10px;
     }
 
     .header-content {
         width: 100%;
-
         flex-direction: column-reverse;
         align-items: flex-end;
     }
@@ -126,16 +110,52 @@ header {
     }
 }
 
+/* mobile css */
 @media (max-width: 426px) {
+    header {
+        flex-direction: row;
+        padding: 10px;
+        width: 100%;
+        height: 150px;
+    }
 
     .logo {
         height: 55px;
+        margin-left: 0;
+        left: 10px;
+        position: static;
     }
 
-    .menu {
-        gap: 5px;
-        padding-left: 10px;
+    .header-content {
+        flex-direction: column wrap;
+        align-items: center;
+        gap: 10px;
+        width: 100%;
     }
+
+    .stat-container {
+        flex-direction: row;
+        justify-content: center;
+        gap: 15px;
+        max-width: 100%;
+        max-height: 35%;
+        margin-right: 70px;
+        margin-bottom: 3px;
+        margin-top: 5px;
+    }
+
+    .stat {
+        height: auto;
+        padding: 5px;
+        flex-direction: row;
+        align-items: center;
+    }
+
+    .stat p {
+        margin: 0;
+        font-size: 15px;
+    }
+
 
     .menu a {
         margin-left: 5px;

--- a/source/snippetCreation/snippetCreation.css
+++ b/source/snippetCreation/snippetCreation.css
@@ -2,7 +2,7 @@
 #snippet {
   display: block;
   position: absolute;
-  top: 1005px; /* CURRENT: header + 20px = 105px; PREV: 116px / 1024px */
+  top: 105px; /* CURRENT: header + 20px = 105px; PREV: 116px / 1024px */
   right: 1.4%; /* 20px / 1440px */
 
   height: 52.54%; /* 538px / 1024px */

--- a/source/snippetCreation/snippetCreation.css
+++ b/source/snippetCreation/snippetCreation.css
@@ -2,7 +2,7 @@
 #snippet {
   display: block;
   position: absolute;
-  top: 105px; /* CURRENT: header + 20px = 105px; PREV: 116px / 1024px */
+  top: 1005px; /* CURRENT: header + 20px = 105px; PREV: 116px / 1024px */
   right: 1.4%; /* 20px / 1440px */
 
   height: 52.54%; /* 538px / 1024px */


### PR DESCRIPTION
## Tracking Info

Resolves #104 

## Changes
- added @media for screens less than 256 px
- updated header size 
- fixed layout of stats in header to  rows
- adjust the sizing of stats, menu, and logo

## Testing
- ran on live server and used devtool to change screen size

## Confirmation of Change
![image](https://github.com/cse110-sp24-group14/cse110-sp24-group14/assets/130100312/1ffbfac1-9847-440e-bbd1-5f79887afb31)

(Snippets box covers navbar, so temp moved it for screenshot) 
(also struggled with fixing gap between top row [logo and menu] and bottom row [stats])
