### PR TITLE
Advaith/fix responsiveness header and snippets

### DIFF
--- a/source/header/header.css
+++ b/source/header/header.css
@@ -161,3 +161,28 @@ header {
         margin-left: 5px;
     }
 }
+
+@media (max-width: 321px) {
+    .stat {
+        height: auto;
+        padding: 1px;
+        flex-direction: row;
+        align-items: center;
+    }
+
+    .stat p {
+        font-size: 13px;
+    }
+
+    .menu {
+        width: 100%;
+        margin-left: 15px;
+        padding: 0 5px;
+        gap: 1px; 
+    }
+
+
+
+
+
+}

--- a/source/header/header.css
+++ b/source/header/header.css
@@ -127,21 +127,19 @@ header {
     }
 
     .header-content {
-        flex-direction: column wrap;
-        align-items: center;
+        align-items: flex-end;
         gap: 10px;
-        width: 100%;
+
+        margin-left: -50px;
     }
 
     .stat-container {
         flex-direction: row;
         justify-content: center;
         gap: 15px;
-        max-width: 100%;
+        
         max-height: 40%;
-        margin-right: 70px;
-        margin-bottom: 3px;
-        margin-top: 5px;
+        margin: 5px 3px;
     }
 
     .stat {
@@ -163,37 +161,7 @@ header {
 }
 
 @media (max-width: 321px) {
-    .stat {
-        height: auto;
-        padding: 1px;
-        flex-direction: row;
-        align-items: center;
-    }
-
     .stat p {
-        font-size: 13px;
+        font-size: 12px;
     }
-
-    .menu {
-        width: 100%;
-        margin-left: 15px;
-        padding: 0 5px;
-        gap: 1px; 
-    }
-
-}
-
-@media (max-width: 375px) {
-
-    .menu {
-        width: 100%;
-        margin-left: 15px;
-        padding: 0 5px;
-        gap: 1px; 
-    }
-
-    .stat p {
-        font-size: 14px;
-    }
-
 }

--- a/source/header/header.css
+++ b/source/header/header.css
@@ -181,8 +181,19 @@ header {
         gap: 1px; 
     }
 
+}
 
+@media (max-width: 375px) {
 
+    .menu {
+        width: 100%;
+        margin-left: 15px;
+        padding: 0 5px;
+        gap: 1px; 
+    }
 
+    .stat p {
+        font-size: 14px;
+    }
 
 }

--- a/source/snippetCreation/snippetCreation.css
+++ b/source/snippetCreation/snippetCreation.css
@@ -149,3 +149,10 @@
   padding: 0 !important;
   margin: 0 !important;
 }
+
+/* media query to hide snippet container for mobile devices */
+@media (max-width: 426px){
+  #snippet{
+    display: none;
+  }
+}

--- a/source/snippetCreation/snippetCreation.js
+++ b/source/snippetCreation/snippetCreation.js
@@ -35,8 +35,8 @@ document.addEventListener('DOMContentLoaded', () => {
         // Alert message
         let text = document.getElementById("alert");
         text.textContent = "Snippet added!";
-        if (text.classList.contains("fade-in")) {clearTimeout(ongoing);}    // if prev call in action: reset timer
-        else {text.classList.add("fade-in");}                               // else, create message
+        if (text.classList.contains("fade-in")) { clearTimeout(ongoing); }    // if prev call in action: reset timer
+        else { text.classList.add("fade-in"); }                               // else, create message
         ongoing = setTimeout(function () {
             text.classList.remove("fade-in");
         }, 2000); // Set time out to three seconds to account for the second the element fades in
@@ -59,9 +59,8 @@ document.addEventListener('DOMContentLoaded', () => {
  */
 const snippetCompleted = (code, language) => {
     fetch(
-        `/add-snippet?code=${
-            code.replaceAll(/'/g, "\\'")
-                .replaceAll(/\n/g, '\\\\n')}&language=${language}`,
+        `/add-snippet?code=${code.replaceAll(/'/g, "\\'")
+            .replaceAll(/\n/g, '\\\\n')}&language=${language}`,
         { method: 'POST' }
     );
     psuedoUpdateSnippetCount();
@@ -120,7 +119,7 @@ function displaySnippets(snippets) {
         const snippetType = document.createElement('p');
         snippetType.className = 'snippet-type';
         snippetType.innerHTML = snippet.code_language;
-        
+
         // Add pre code for snippet highlighting
         const pre = document.createElement('pre');
         const code = document.createElement('code');
@@ -129,7 +128,7 @@ function displaySnippets(snippets) {
             .replaceAll(/\\n/g, '\n')
             .replaceAll(/</g, '&lt;')
             .replaceAll(/>/g, '&gt;') // replace string literal with new lines
-        
+
         pre.append(code);
         snippetText.appendChild(pre);
 
@@ -140,9 +139,9 @@ function displaySnippets(snippets) {
 
         // Add box to container
         snippetBox.appendChild(snippetText);
-        snippetBox.appendChild(snippetType);    
+        snippetBox.appendChild(snippetType);
         container.appendChild(snippetBox);
-        
+
     });
 }
 
@@ -191,8 +190,8 @@ function copy(button) {
     // Alert message
     let text = document.getElementById("alert");
     text.textContent = "Copied to clipboard!";
-    if (text.classList.contains("fade-in")) {clearTimeout(ongoing);}    // if prev call in action: reset timer
-    else {text.classList.add("fade-in");}                               // else, create message
+    if (text.classList.contains("fade-in")) { clearTimeout(ongoing); }    // if prev call in action: reset timer
+    else { text.classList.add("fade-in"); }                               // else, create message
     ongoing = setTimeout(function () {
         text.classList.remove("fade-in");
     }, 2000); // Set time out to three seconds to account for the second the element fades in


### PR DESCRIPTION
<!-- Make sure your title explains the purpose of the PR concisely -->

## Tracking Info

Resolves #<issue number>

<!-- Alternatively, provide a concise description of the task if this does not close any issues -->
Fixes some issues with header responsiveness, particularly for medium and small sized mobile devices. The "menu" element was not fully on the yellow header bar. The text inside the stat boxes of header also started flowing outside of it.
## Changes

<!-- What changes did you make? Account for everything but keep it brief. -->

- Added sections in header/header.css to account for max size of 321px and 375px.

## Testing

<!-- How did you confirm your changes worked? (Make sure to test locally first!) -->

- ran server locally
- changed size of screen in devtools to account for both medium and small phone sizes

## Confirmation of Change

<!-- Upload a screenshot, if possible. Otherwise, please provide instructions on how to see the change. -->
For small mobile devices
<img width="143" alt="Screen Shot 2024-06-08 at 9 23 37 PM" src="https://github.com/cse110-sp24-group14/cse110-sp24-group14/assets/80607809/53e63f4d-54e2-42f3-a8ea-cf01c8904170">

Medium mobile devices
<img width="173" alt="Screen Shot 2024-06-08 at 9 24 07 PM" src="https://github.com/cse110-sp24-group14/cse110-sp24-group14/assets/80607809/5eb93747-cf31-4ba4-87b4-06bd8e8ad2d8">



