### PR TITLE
Prevent default scrolling of body when mouse over sidebar

### DIFF
--- a/source/sideCalendar/sideCalendar.js
+++ b/source/sideCalendar/sideCalendar.js
@@ -200,6 +200,8 @@ class SideCalendar extends HTMLElement {
         this.shadowRoot.appendChild(nextWeekButton);
 
         this.setGlobalDate(new Date);
+
+        this.preventScrollOnTable();
     }
 
     /**
@@ -287,6 +289,30 @@ class SideCalendar extends HTMLElement {
             }
             this.setGlobalDate(dateTemp);
         };
+    }
+
+    preventScrollOnTable() {
+        const table = this.shadowRoot.querySelector('table')
+        const body = document.querySelector('body');
+
+        let mouseIsOver = false;
+
+        table.onmouseover = () => {
+            mouseIsOver = true
+        }
+
+        table.onmouseleave = () => {
+            mouseIsOver = false;
+        }
+
+        // prevents body scrolling when over table
+        body.addEventListener('wheel', (e) => {
+            if (mouseIsOver) {
+                e.preventDefault();
+                e.stopPropagation();
+                return false;
+            }
+        }, { passive: false });
     }
 }
 

--- a/source/sideCalendar/sideCalendar.js
+++ b/source/sideCalendar/sideCalendar.js
@@ -291,6 +291,9 @@ class SideCalendar extends HTMLElement {
         };
     }
 
+    /**
+     * Prevents body scrolling when mosue is over table
+     */
     preventScrollOnTable() {
         const table = this.shadowRoot.querySelector('table')
         const body = document.querySelector('body');


### PR DESCRIPTION
<!-- Make sure your title explains the purpose of the PR concisely -->

## Tracking Info

Resolves #121 

<!-- Alternatively, provide a concise description of the task if this does not close any issues -->

## Changes

<!-- What changes did you make? Account for everything but keep it brief. -->

- Add event listeners to listen when mouse over sidebar calendar
- Prevent the default behavior of the body to stop scrolling

## Testing

<!-- How did you confirm your changes worked? (Make sure to test locally first!) -->

- Tested different positions of the mouse
- Tested the regular functions to ensure everything else depending on the sidebar still functions

## Confirmation of Change

<!-- Upload a screenshot, if possible. Otherwise, please provide instructions on how to see the change. -->

1. Scroll outside of the table - it should scroll the body
2. Scroll inside the table - it should not be able to scroll the body and only scroll the calendar
